### PR TITLE
Fix file reference leak after zip file exception

### DIFF
--- a/lib/apkreader.js
+++ b/lib/apkreader.js
@@ -39,7 +39,10 @@ class ApkReader {
         }
 
         readableListener = () => tryRead()
-        errorListener = err => reject(err)
+        errorListener = err => {
+          stream.destroy();
+          reject(err)
+        }
         endListener = () => resolve(Buffer.concat(chunks, totalLength))
 
         stream.on('readable', readableListener)


### PR DESCRIPTION
Just use a normal file such as a png, rename it to HelloApp.apk
Test Demo:
```javascript
const util = require('util')
const ApkReader = require('adbkit-apkreader')

process.stdin.resume();// prevent the current process from exit

ApkReader.open('HelloApp.apk')
  .then(reader => reader.readManifest())
  .then(manifest => console.log(util.inspect(manifest, { depth: null }))).catch(function(e) {
    console.error(e);
  })
```

then run the demo 

After that, the code above will catch the zlib error.

But use the command below , you will find that there is a reference leak for  the HelloApp.apk.
```bash
lsof -s|grep HelloApp.apk
```